### PR TITLE
Add PDF text extraction utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # gpt
+
+This repository provides a simple script to extract the text layer from a PDF using `pdfjs-dist`.
+
+## Usage
+
+1. Install dependencies:
+   ```bash
+   npm install pdfjs-dist
+   ```
+2. Run the script:
+   ```bash
+   node extract_text.js path/to/file.pdf > output.txt
+   ```
+   The text content of the PDF will be printed to stdout and can be redirected to a file.

--- a/extract_text.js
+++ b/extract_text.js
@@ -1,0 +1,15 @@
+const fs = require('fs');
+const pdfParse = require('pdf-parse');
+
+if (process.argv.length < 3) {
+  console.error('Usage: node extract_text.js <pdf-file>');
+  process.exit(1);
+}
+
+const dataBuffer = fs.readFileSync(process.argv[2]);
+
+pdfParse(dataBuffer).then(function(data) {
+  console.log(data.text);
+}).catch(function(err) {
+  console.error('Error: ' + err);
+});


### PR DESCRIPTION
## Summary
- add `extract_text.js` using `pdf-parse`
- document how to use the script in README

## Testing
- `node extract_text.js sample.pdf` *(fails: Invalid PDF structure)*

------
https://chatgpt.com/codex/tasks/task_e_684b903e4d74833285254caeb0e40998